### PR TITLE
Allow download from safari

### DIFF
--- a/src/ng-csv/directives/ng-csv.js
+++ b/src/ng-csv/directives/ng-csv.js
@@ -102,7 +102,9 @@ angular.module('ngCsv.directives').
                 var downloadLink = angular.element(downloadContainer.children()[0]);
                 downloadLink.attr('href', window.URL.createObjectURL(csvData));
                 downloadLink.attr('download', scope.getFilename());
-                downloadLink.attr('target', '_blank');
+                if(navigator.userAgent.toLowerCase().indexOf('safari') === -1) {
+                  downloadLink.attr('target', '_blank');
+                }
 
                 $document.find('body').append(downloadContainer);
                 $timeout(function () {


### PR DESCRIPTION
I was able to download a csv from safari as long as I prevented the blob from trying to open in a new page.